### PR TITLE
Removing external gulp and bower dependencies. Getting rid of ruby-sass.

### DIFF
--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -2,10 +2,10 @@ module.exports = function(environment) {
   'use strict';
   var gulp = require('gulp');
   var run = require('run-sequence');
-  var sass = require('gulp-ruby-sass');
+  var sass = require('gulp-sass');
   var minifycss = require('gulp-minify-css');
   var rename = require('gulp-rename');
-  var scsslint = require('gulp-scss-lint');
+ // var scsslint = require('gulp-scss-lint');
   var rimraf = require('rimraf');
 
 
@@ -23,11 +23,11 @@ module.exports = function(environment) {
       .pipe(scsslint());
   });
 
-  gulp.task('sass', function() {
-    return sass('./core/scss/core.scss')
-      .pipe(gulp.dest('./target/css/'));
+  gulp.task('sass', function () {
+    gulp.src('./core/scss/core.scss')
+        .pipe(sass().on('error', sass.logError))
+        .pipe(gulp.dest('./target/css/'));
   });
-
 
   gulp.task('minify-css', function() {
     return gulp.src(['./target/css/*.css'])
@@ -40,7 +40,7 @@ module.exports = function(environment) {
 
   gulp.task('styles', function() {
     return run('clean-styles',
-      'scss-lint',
+    //  'scss-lint',
       'sass',
       'minify-css');
   });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git@github.com:orionstein/boilerplatitude.git"
   },
   "devDependencies": {
+    "bower": "^1.4.1",
     "coffeelint": "^1.9.3",
     "coffeelint-stylish": "^0.1.2",
     "gulp": "^3.8.11",
@@ -29,7 +30,8 @@
     "browserify": "^9.0.4",
     "browserify-shim": "^3.8.5",
     "coffeeify": "^1.0.0",
-    "gulp-htmltidy": "^0.2.2"
+    "gulp-htmltidy": "^0.2.2",
+    "gulp-sass": "^2.0.1"
   },
   "browserify": {
     "transform": [
@@ -40,6 +42,11 @@
     "jquery": "global:$",
     "angular": "global:angular",
     "ui-router": "global:ui-router",
-	"lodash": "global:_"
+    "lodash": "global:_"
+  },
+  "scripts": {
+    "start": "node ./node_modules/gulp/bin/gulp.js",
+    "bower": "node ./node_modules/bower/bin/bower install ",
+    "development": "node ./node_modules/gulp/bin/gulp.js development"
   }
 }


### PR DESCRIPTION
Just an idea...
Move some of your build command to scripts within package.json. Removes the need to have gulp/grunt and bower installed globally. 

Also,
Removing ruby-sass and using the libsass instead. I don't want to install all these ruby gems!

There doesn't seem to be a non-ruby alternative to scss-lint... so that's a problem...
